### PR TITLE
Add order key to entry query arguments

### DIFF
--- a/src/Http/Resources/CollectionResource.php
+++ b/src/Http/Resources/CollectionResource.php
@@ -111,8 +111,11 @@ class CollectionResource extends Resource
             ->updateWheres($wheres);
 
         if (Arr::has($args, 'order')) {
-            [$column, $direction] = explode('::', Arr::get($args, 'order'));
-            $query = $query->orderBy($column, $direction ?? 'asc');
+            $column = explode('::', Arr::get($args, 'order'));
+
+            $direction = $column[1] ?? 'asc';
+
+            $query = $query->orderBy($column[0], $direction);
         }
 
         if ($this->value->dated() && !Arr::has($args, 'order')) {

--- a/src/Http/Resources/CollectionResource.php
+++ b/src/Http/Resources/CollectionResource.php
@@ -110,7 +110,12 @@ class CollectionResource extends Resource
         $query = $this->value->queryEntries()
             ->updateWheres($wheres);
 
-        if ($this->value->dated()) {
+        if (Arr::has($args, 'order')) {
+            [$column, $direction] = explode('::', Arr::get($args, 'order'));
+            $query = $query->orderBy($column, $direction ?? 'asc');
+        }
+
+        if ($this->value->dated() && !Arr::has($args, 'order')) {
             $query = $query->orderBy('date', $this->value->sortDirection());
         }
 


### PR DESCRIPTION
This adds support for a custom order in the entry query.
Query arguments may use 'order' key and a valid field as value.
Order direction may be set by adding '::{direction}' to the value. Default direction is 'asc'.

Like so: 
```
$this->entries([
    'perPage' => 20,
    'order' => 'title::desc'
])
```