### PR TITLE
Allow to order collection entries by any column

### DIFF
--- a/src/Http/Resources/CollectionResource.php
+++ b/src/Http/Resources/CollectionResource.php
@@ -113,6 +113,12 @@ class CollectionResource extends Resource
         if ($this->value->dated()) {
             $query = $query->orderBy('date', $this->value->sortDirection());
         }
+        
+        if (Arr::has($args, 'order')) {
+            [$column, $direction] = explode(',', Arr::get($args, 'order').',asc');
+            
+            $query = $query->orderBy($column, $direction);
+        }
 
         if (Arr::has($args, 'limit')) {
             $query = $query->limit($args['limit']);


### PR DESCRIPTION
This allows to manually order collection entries by any of its attributes.

```php
// Within any CollectionResource

$this->entries(['order' => 'id,desc']);
```

___

Superseed: #1 